### PR TITLE
New RMS proposal for systematic uncertainty

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Everything will be done for a specific flag (so the settings can be the same for
    ```
 
 5. **Do your first round of fits.**
+   
+   ***KEEP IN MIND:*** please check that all of the fits have converged correctly and don't allow for extreme low mass tail variations as these can't be considered as valid fits (see S8 in presentation https://indico.cern.ch/event/1288547/contributions/5414376/attachments/2654622/4597206/26052023_RMS_EGamma.pdf) 
    1. nominal fit
 
       ```bash
@@ -131,7 +133,7 @@ Everything will be done for a specific flag (so the settings can be the same for
       python tnpEGM_fitter.py etc/config/settings.py --flag myWP --doFit --mcSig --altSig --iBin ib
       ```
 
-6. **egm txt ouput file.** Once all fits are fine, put everything in the egm format txt file
+7. **egm txt ouput file.** Once all fits are fine, put everything in the egm format txt file
 
    ```bash
    python tnpEGM_fitter.py etc/config/setting.py  --flag myWP --sumUp

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Everything will be done for a specific flag (so the settings can be the same for
       ```bash
       python tnpEGM_fitter.py etc/config/settings.py --flag myWP --doFit  --altBkg
       ```
+   5. Alternate signal + background fit (using constraints from previous fits)
+
+      ```bash
+      python tnpEGM_fitter.py etc/config/settings.py --flag myWP --doFit  --altSigBkg
+      ```
    5. **Check fits and redo failed ones.** (there is a web `index.php` in the plot directory to vizualize from the web)
       - can redo a given bin using its bin number ib. The bin number can be found from `--checkBins`, directly in the ouput dir (or web interface)
 

--- a/etc/config/settings_UL2017_RMS_pt11_15.py
+++ b/etc/config/settings_UL2017_RMS_pt11_15.py
@@ -1,0 +1,164 @@
+#############################################################
+########## General settings
+#############################################################
+# flag to be Tested
+cutpass80 = '(( abs(probe_sc_eta) < 0.8 && probe_Ele_nonTrigMVA > %f ) ||  ( abs(probe_sc_eta) > 0.8 && abs(probe_sc_eta) < 1.479&& probe_Ele_nonTrigMVA > %f ) || ( abs(probe_sc_eta) > 1.479 && probe_Ele_nonTrigMVA > %f ) )' % (0.967083,0.929117,0.726311)
+cutpass90 = '(( abs(probe_sc_eta) < 0.8 && probe_Ele_nonTrigMVA > %f ) ||  ( abs(probe_sc_eta) > 0.8 && abs(probe_sc_eta) < 1.479&& probe_Ele_nonTrigMVA > %f ) || ( abs(probe_sc_eta) > 1.479 && probe_Ele_nonTrigMVA > %f ) )' % (0.913286,0.805013,0.358969)
+
+runs="BCDEF"
+
+# flag to be Tested
+flags = {
+    'passingVeto'   : '(passingVeto   == 1)',
+    'passingLoose'  : '(passingLoose  == 1)',
+    'passingMedium' : '(passingMedium == 1)',
+    'passingTight'  : '(passingTight  == 1)',
+    'passingMVA80'  : cutpass80,
+    'passingMVA90'  : cutpass90,
+    'passingElID17UL_Ana'   : '(el_IsoMVA17UL   == 1 && fabs(el_sip) < 4 && fabs(el_dz) < 1 && fabs(el_dxy) < 0.5)',
+    }
+# baseOutDir = '/eos/user/a/asculac/test_altSigaltBkg_lowpt_mergedEta'
+baseOutDir = '/eos/user/a/asculac/final_RMS_egm_TEST_midpt'
+#############################################################
+########## samples definition  - preparing the samples
+#############################################################
+### samples are defined in etc/inputs/tnpSampleDef.py
+### not: you can setup another sampleDef File in inputs
+import etc.inputs.tnpSampleDef_17 as tnpSamples
+tnpTreeDir = 'tnpEleIDs' 
+
+samplesDef = {
+    'data'   : tnpSamples.Moriond18_94X['data_Run2017{0}'.format(runs[0])].clone(),
+    'mcNom'  : tnpSamples.Moriond18_94X['DY_madgraph'].clone(),
+    'mcAlt'  : tnpSamples.Moriond18_94X['DY_amcatnlo'].clone(),
+    'tagSel' : tnpSamples.Moriond18_94X['DY_madgraph'].clone(),
+}
+
+## can add data sample easily
+
+for r in runs[1:]:
+    samplesDef['data'].add_sample( tnpSamples.Moriond18_94X['data_Run2017{0}'.format(r)] )
+
+## some sample-based cuts... general cuts defined here after
+## require mcTruth on MC DY samples and additional cuts
+## all the samples MUST have different names (i.e. sample.name must be different for all)
+## if you need to use 2 times the same sample, then rename the second one
+#samplesDef['data'  ].set_cut('run >= 273726')
+samplesDef['data' ].set_tnpTree(tnpTreeDir)
+if not samplesDef['mcNom' ] is None: samplesDef['mcNom' ].set_tnpTree(tnpTreeDir)
+if not samplesDef['mcAlt' ] is None: samplesDef['mcAlt' ].set_tnpTree(tnpTreeDir)
+if not samplesDef['tagSel'] is None: samplesDef['tagSel'].set_tnpTree(tnpTreeDir)
+#if not samplesDef['mcAlt_tagSel'] is None: samplesDef['mcAlt_tagSel'].set_tnpTree(tnpTreeDir)
+
+if not samplesDef['mcNom' ] is None: samplesDef['mcNom' ].set_mcTruth()
+if not samplesDef['mcAlt' ] is None: samplesDef['mcAlt' ].set_mcTruth()
+if not samplesDef['tagSel'] is None: samplesDef['tagSel'].set_mcTruth()
+if not samplesDef['tagSel'] is None:
+    samplesDef['tagSel'].rename('mcAltSel_DY_madgraph')
+    samplesDef['tagSel'].set_cut('tag_Ele_pt > 37') #canceled non trig MVA cut
+# if not samplesDef['mcAlt_tagSel'] is None: samplesDef['mcAlt_tagSel'].set_mcTruth()
+# if not samplesDef['mcAlt_tagSel'] is None:
+#     samplesDef['mcAlt_tagSel'].rename('mcAlt_tag_DY_madgraph')
+#     samplesDef['mcAlt_tagSel'].set_cut('tag_Ele_pt > 37') #apply tag cut on alt mc
+
+## set MC weight, simple way (use tree weight) 
+#weightName = 'totWeight'
+#if not samplesDef['mcNom' ] is None: samplesDef['mcNom' ].set_weight(weightName)
+#if not samplesDef['mcAlt' ] is None: samplesDef['mcAlt' ].set_weight(weightName)
+#if not samplesDef['tagSel'] is None: samplesDef['tagSel'].set_weight(weightName)
+
+## set MC weight, can use several pileup rw for different data taking periods
+weightName = 'weights_2017_runBCDEF.totWeight'
+if not samplesDef['mcNom' ] is None: samplesDef['mcNom' ].set_weight(weightName)
+if not samplesDef['mcAlt' ] is None: samplesDef['mcAlt' ].set_weight(weightName)
+if not samplesDef['tagSel'] is None: samplesDef['tagSel'].set_weight(weightName)
+# if not samplesDef['mcAlt_tagSel'] is None: samplesDef['mcAlt_tagSel'].set_weight(weightName)
+if not samplesDef['mcNom' ] is None: samplesDef['mcNom' ].set_puTree('/eos/cms/store/group/phys_egamma/swmukher/UL2017/PU_miniAOD/DY_amcatnloext_ele.pu.puTree.root')
+if not samplesDef['mcAlt' ] is None: samplesDef['mcAlt' ].set_puTree('/eos/cms/store/group/phys_egamma/swmukher/UL2017/PU_miniAOD/DY_madgraph_ele.pu.puTree.root')
+if not samplesDef['tagSel'] is None: samplesDef['tagSel'].set_puTree('/eos/cms/store/group/phys_egamma/swmukher/UL2017/PU_miniAOD/DY_amcatnloext_ele.pu.puTree.root')
+
+######### 2017 ##############
+#merged eta
+# biningDef = [
+
+#     { 'var' : 'el_sc_eta' , 'type': 'float', 'bins': [-2.5, 2.5] },
+#     { 'var' : 'el_pt' , 'type': 'float', 'bins': [7, 11, 15] },
+# ]
+
+# biningDef = [
+
+#     { 'var' : 'el_sc_eta' , 'type': 'float', 'bins': [-2.5, -2.3, -2.0, -1.7, -1.5, -1.3, -1.0, -0.5, 0, 0.5, 1.0, 1.3, 1.5, 1.7, 2.0, 2.3, 2.5] },
+#     { 'var' : 'el_pt' , 'type': 'float', 'bins': [35, 50] },
+# ]
+
+biningDef = [
+    # very low pt
+    # { 'var' : 'el_sc_abseta' , 'type': 'float', 'bins': [0.0, 0.5, 1.0, 1.5, 2.0, 2.5] },
+    # { 'var' : 'el_pt' , 'type': 'float', 'bins': [7, 11] },
+   
+    # #low pt
+    { 'var' : 'el_sc_eta' , 'type': 'float', 'bins': [-2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5] },
+    { 'var' : 'el_pt' , 'type': 'float', 'bins': [11, 15] },
+]
+#############################################################
+########## Cuts definition for all samples
+#############################################################
+### cut
+cutBase   = 'tag_Ele_pt > 30 && abs(tag_sc_eta) < 2.17 && el_q*tag_Ele_q < 0'
+addCutLowPt = 'tag_Ele_trigMVA > 0.92 && sqrt( 2*event_met_pfmet*tag_Ele_pt*(1-cos(event_met_pfphi-tag_Ele_phi))) < 45 && tag_Ele_pt > 50 '
+addCutLowPtDamir = 'el_3charge==1 '
+
+# can add addtionnal cuts for some bins (first check bin number using tnpEGM --checkBins)
+additionalCuts = {}
+for i in range(10):
+    additionalCuts[i] = "!el_isGap"
+for i in range(10):
+    additionalCuts[i] = additionalCuts[i] + "&& " + addCutLowPt + " && " + addCutLowPtDamir
+
+
+#############################################################
+########## fitting params to tune fit by hand if necessary
+#############################################################
+tnpParNomFit = [
+    "meanP[-0.0,-5.0,5.0]","sigmaP[0.9,0.5,5.0]",
+    "meanF[-0.0,-5.0,5.0]","sigmaF[0.9,0.5,5.0]",
+    "acmsP[60.,50.,80.]","betaP[0.05,0.01,0.08]","gammaP[0.1, -2, 2]","peakP[90.0]",
+    "acmsF[60.,50.,80.]","betaF[0.05,0.01,0.08]","gammaF[0.1, -2, 2]","peakF[90.0]",
+    ]
+
+tnpParAltSigFit = [
+    "meanP[-0.0,-5.0,5.0]","sigmaP[1,0.7,6.0]","alphaP[2.0,1.2,3.5]" ,'nP[3,-5,5]',"sigmaP_2[1.5,0.5,6.0]","sosP[1,0.1,5.0]",
+    "meanF[-0.0,-5.0,5.0]","sigmaF[2,0.7,6.0]","alphaF[2.0,1.2,3.5]",'nF[3,-5,5]',"sigmaF_2[2.0,0.1,10.0]","sosF[1,0.1,5.0]",
+    "acmsP[60.,50.,10000.]","betaP[0.04,0.01,0.07]","gammaP[0.1, 0.005, 1]","peakP[90.0]",
+    "acmsF[60.,50.,500.]","betaF[0.04,0.01,0.05]","gammaF[0.1, 0.005, 1]","peakF[90.5]",
+    ]
+#default for altsig
+#   "meanP[-0.0,-5.0,5.0]","sigmaP[1,0.7,6.0]","alphaP[2.0,1.2,3.5]" ,'nP[3,-5,5]',"sigmaP_2[1.5,0.5,6.0]","sosP[1,0.5,5.0]",
+#     "meanF[-0.0,-5.0,5.0]","sigmaF[2,0.7,15.0]","alphaF[2.0,1.2,3.5]",'nF[3,-5,5]',"sigmaF_2[2.0,0.5,6.0]","sosF[1,0.5,5.0]",
+#     "acmsP[60.,50.,105.]","betaP[0.04,0.01,0.06]","gammaP[0.1, 0.005, 1]","peakP[90.0]",
+#     "acmsF[60.,50.,75.]","betaF[0.04,0.01,0.06]","gammaF[0.1, 0.005, 1]","peakF[90.0]"
+
+tnpParAltSigFit_addGaus = [
+    "meanP[-0.0,-5.0,5.0]","sigmaP[1,0.7,6.0]","alphaP[2.0,1.2,3.5]" ,'nP[3,-5,5]',"sigmaP_2[1.5,0.5,6.0]","sosP[1,0.5,5.0]",
+    "meanF[-0.0,-5.0,5.0]","sigmaF[2,0.7,6.0]","alphaF[2.0,1.2,3.5]",'nF[3,-5,5]',"sigmaF_2[2.0,0.5,6.0]","sosF[1,0.6,5.0]",
+    "meanGF[80.0,70.0,100.0]","sigmaGF[15,5.0,125.0]",
+    "acmsP[60.,50.,75.]","betaP[0.04,0.01,0.06]","gammaP[0.1, 0.005, 1]","peakP[90.0]",
+    "acmsF[60.,50.,85.]","betaF[0.04,0.01,0.06]","gammaF[0.1, 0.005, 1]","peakF[90.0]",
+    ]
+         
+tnpParAltBkgFit = [
+    "meanP[-0.0,-5.0,5.0]","sigmaP[0.9,0.5,5.0]",
+    "meanF[-0.0,-5.0,5.0]","sigmaF[0.9,0.5,5.0]",
+    "alphaP[0.,-5.,5.]",
+    "alphaF[0,-0.045,0.045]",
+    ]
+
+tnpParAltSigBkgFit = [
+    "meanP[-0.0,-5.0,5.0]","sigmaP[1,0.7,6.0]","alphaP[2.0,0.0,3.5]" ,'nP[3,-5,5]',"sigmaP_2[1.5,0.5,6.0]","sosP[1,0.1,5.0]",
+    "meanF[-0.0,-5.0,5.0]","sigmaF[2,0.7,6.0]","alphaF[2.0,0.0,3.5]",'nF[3,-5,5]',"sigmaF_2[2.0,0.1,10.0]","sosF[1,0.1,5.0]",
+    "alphaP_2[0.,-5.,5.]",
+    "alphaF_2[0,-5.,5.]",
+    #--above was ok for 11-15 pt
+
+]
+    

--- a/etc/inputs/tnpSampleDef_17.py
+++ b/etc/inputs/tnpSampleDef_17.py
@@ -1,0 +1,24 @@
+from libPython.tnpClassUtils import tnpSample
+
+### qll stat
+summer19 = '/data_CMS/cms/asculac/TnP_tuples/UL2017/data/Summer19/'
+
+Moriond18_94X = {
+    ### MiniAOD TnP for IDs scale factors
+    'DY_madgraph'              : tnpSample('DY_madgraph',
+                                      # '/data_CMS/cms/asculac/TnP_tuples/UL2017/mc/Summer19/DY_19UL17_madgraph.root',
+                                     '/data_CMS/cms/asculac/TnP_tuples/UL2017/mc/Summer20/DYJetsToLL_magraph_20UL17.root',
+                                       isMC = True, nEvts =  -1 ),
+    'DY_amcatnlo'                 : tnpSample('DY_amcatnlo',
+                                       '/data_CMS/cms/asculac/TnP_tuples/UL2017/mc/Summer20/DY_amcatnlo_miniADOv2_20UL17.root', ##UPDATED TO SUMMER20
+                                       isMC = True, nEvts =  -1 ),
+
+
+
+    'data_Run2017B' : tnpSample('data_Run2017B' , summer19 + 'data_RunB_2017.root' , lumi = 4.793961427),
+    'data_Run2017C' : tnpSample('data_Run2017C' , summer19 + 'data_RunC_2017.root' , lumi = 9.631214821 ),
+    'data_Run2017D' : tnpSample('data_Run2017D' , summer19 + 'data_RunD_2017.root' , lumi = 4.247682053 ),
+    'data_Run2017E' : tnpSample('data_Run2017E' , summer19 + 'data_RunE_2017.root' , lumi = 9.313642402 ),
+    'data_Run2017F' : tnpSample('data_Run2017F' , summer19 + 'data_RunF_2017.root' , lumi = 13.510934811),
+
+    }

--- a/libPython/EGammaID_scaleFactors.py
+++ b/libPython/EGammaID_scaleFactors.py
@@ -16,10 +16,9 @@ effiMin = 0.68
 effiMax = 1.07
 
 
-# sfMin = 0.78
-# sfMax = 1.12
-sfMin = 0.8
-sfMax = 1.2
+sfMin = 0.78
+sfMax = 1.12
+
 
 def isFloat( myFloat ):
     try:
@@ -139,8 +138,8 @@ def EffiGraph1D(effDataList, effMCList, sfList ,nameout, xAxis = 'pT', yAxis = '
 
     sfminmax =  findMinMax( sfList )
     sfMin = sfminmax[0]
-    sfMin = 0.8
-    sfMax = 1.2
+    sfMin = 0.78
+    sfMax = 1.12
 
     for key in sorted(effDataList.keys()):
         grBinsEffData = effUtil.makeTGraphFromList(effDataList[key], 'min', 'max')
@@ -316,22 +315,23 @@ def doEGM_SFs(filein, lumi, axis = ['pT','eta'] ):
 
     fileWithEff.close()
 ### massage the numbers a bit
-    # effGraph.symmetrizeSystVsEta()# -----CHECK IF WE SHOULD KEEP IT (looks the same?)
+    # effGraph.symmetrizeSystVsEta()# ----- REMOVING SYMM ETA AS DISCUSSED WITH RICCARDO
     effGraph.combineSyst()
 
     print " ------------------------------- "
 
     customEtaBining = []
-#     customEtaBining.append( (0.000,0.800))
-#     customEtaBining.append( (0.800,1.444))
-# #    customEtaBining.append( (1.444,1.566))
-#     customEtaBining.append( (1.566,2.000))
-#     customEtaBining.append( (2.000,2.500))
-    customEtaBining.append( (0.000,0.500))
-    customEtaBining.append( (0.500,1.0))    
-    customEtaBining.append( (1.000,1.5))
-    customEtaBining.append( (1.5,2.000))
+    customEtaBining.append( (0.000,0.800))
+    customEtaBining.append( (0.800,1.444))
+#    customEtaBining.append( (1.444,1.566)) #gap region
+    customEtaBining.append( (1.566,2.000))
     customEtaBining.append( (2.000,2.500))
+    #HZZ bins - can be deleted
+    # customEtaBining.append( (0.000,0.500))
+    # customEtaBining.append( (0.500,1.0))    
+    # customEtaBining.append( (1.000,1.5))
+    # customEtaBining.append( (1.5,2.000))
+    # customEtaBining.append( (2.000,2.500))
 
 
 

--- a/libPython/EGammaID_scaleFactors.py
+++ b/libPython/EGammaID_scaleFactors.py
@@ -15,9 +15,11 @@ tdrstyle.setTDRStyle()
 effiMin = 0.68
 effiMax = 1.07
 
-sfMin = 0.78
-sfMax = 1.12
 
+# sfMin = 0.78
+# sfMax = 1.12
+sfMin = 0.8
+sfMax = 1.2
 
 def isFloat( myFloat ):
     try:
@@ -137,8 +139,8 @@ def EffiGraph1D(effDataList, effMCList, sfList ,nameout, xAxis = 'pT', yAxis = '
 
     sfminmax =  findMinMax( sfList )
     sfMin = sfminmax[0]
-    sfMin = 0.78
-    sfMax = 1.12
+    sfMin = 0.8
+    sfMax = 1.2
 
     for key in sorted(effDataList.keys()):
         grBinsEffData = effUtil.makeTGraphFromList(effDataList[key], 'min', 'max')
@@ -305,7 +307,6 @@ def doEGM_SFs(filein, lumi, axis = ['pT','eta'] ):
         if len(numbers) > 0 and isFloat(numbers[0]):
             etaKey = ( float(numbers[0]), float(numbers[1]) )
             ptKey  = ( float(numbers[2]), min(500,float(numbers[3])) )
-        
             myeff = efficiency(ptKey,etaKey,
                                float(numbers[4]),float(numbers[5]),float(numbers[6] ),float(numbers[7] ),
                                float(numbers[8]),float(numbers[9]),float(numbers[10]),float(numbers[11]) )
@@ -314,34 +315,38 @@ def doEGM_SFs(filein, lumi, axis = ['pT','eta'] ):
             effGraph.addEfficiency(myeff)
 
     fileWithEff.close()
-
 ### massage the numbers a bit
-    effGraph.symmetrizeSystVsEta()
+    # effGraph.symmetrizeSystVsEta()# -----CHECK IF WE SHOULD KEEP IT (looks the same?)
     effGraph.combineSyst()
 
     print " ------------------------------- "
 
     customEtaBining = []
-    customEtaBining.append( (0.000,0.800))
-    customEtaBining.append( (0.800,1.444))
-#    customEtaBining.append( (1.444,1.566))
-    customEtaBining.append( (1.566,2.000))
+#     customEtaBining.append( (0.000,0.800))
+#     customEtaBining.append( (0.800,1.444))
+# #    customEtaBining.append( (1.444,1.566))
+#     customEtaBining.append( (1.566,2.000))
+#     customEtaBining.append( (2.000,2.500))
+    customEtaBining.append( (0.000,0.500))
+    customEtaBining.append( (0.500,1.0))    
+    customEtaBining.append( (1.000,1.5))
+    customEtaBining.append( (1.5,2.000))
     customEtaBining.append( (2.000,2.500))
+
 
 
     pdfout = nameOutBase + '_egammaPlots.pdf'
     cDummy = rt.TCanvas()
     cDummy.Print( pdfout + "[" )
 
-
     EffiGraph1D( effGraph.pt_1DGraph_list_customEtaBining(customEtaBining, False ) , #eff Data
                  None, 
                  effGraph.pt_1DGraph_list_customEtaBining(customEtaBining, True ) , #SF
                  pdfout,
                  xAxis = axis[0], yAxis = axis[1] )
-#EffiGraph1D( effGraph.pt_1DGraph_list_customEtaBining(customEtaBining,False) , 
-#             effGraph.pt_1DGraph_list_customEtaBining(customEtaBining,True)   , False, pdfout )
-#    EffiGraph1D( effGraph.eta_1DGraph_list(False), effGraph.eta_1DGraph_list(True), True , pdfout )
+    # EffiGraph1D( effGraph.pt_1DGraph_list_customEtaBining(customEtaBining,False) , 
+    #         effGraph.pt_1DGraph_list_customEtaBining(customEtaBining,True)   , False, pdfout )
+    # EffiGraph1D( effGraph.eta_1DGraph_list(False), effGraph.eta_1DGraph_list(True), True , pdfout )
     listOfSF1D = EffiGraph1D( effGraph.eta_1DGraph_list( typeGR =  0 ) , # eff Data
                               effGraph.eta_1DGraph_list( typeGR = -1 ) , # eff MC
                               effGraph.eta_1DGraph_list( typeGR = +1 ) , # SF

--- a/libPython/efficiencyUtils.py
+++ b/libPython/efficiencyUtils.py
@@ -93,16 +93,10 @@ class efficiency:
         #     self.systCombined += self.syst[isyst]*self.syst[isyst];
 
         ##NEW PROPOSAL##
-        #print("eta bin: ",self.etaBin[0],self.etaBin[1])
-        #for isyst in range (7):
-           # print("isyst: ", isyst, " syst[isyst]: ", self.syst[isyst])
         for isyst in range(2,6):
-            # print("isyst: ", isyst, " syst[isyst]: ", self.syst[isyst])
-            self.systCombined += self.syst[isyst]*self.syst[isyst]
-        self.systCombined= math.sqrt(self.systCombined/3)
-        #print("no stat: ",self.systCombined )
-        self.systCombined = math.sqrt(self.systCombined*self.systCombined/4 + self.syst[6]*self.syst[6] + self.syst[0]*self.syst[0]+ self.syst[1]*self.syst[1])
-        #print("syst + stat: ",self.systCombined )
+            self.systCombined += self.syst[isyst]*self.syst[isyst] 
+        self.systCombined= math.sqrt(self.systCombined/3) #RMS/sqrtN
+        self.systCombined = math.sqrt(self.systCombined*self.systCombined/4 + self.syst[6]*self.syst[6] + self.syst[0]*self.syst[0]+ self.syst[1]*self.syst[1]) #sum in quad with syst_altMC, statData and statMC
 
     def __add__(self,eff):
         if self.effData < 0 :

--- a/libPython/efficiencyUtils.py
+++ b/libPython/efficiencyUtils.py
@@ -4,12 +4,12 @@ class efficiency:
     #    altEff = [-1]*7
     iAltBkgModel = 0
     iAltSigModel = 1
-    iAltMCSignal = 7
-    iAltTagSelec = 3
+    iAltMCSignal = 2
+    # iAltTagSelec = 3
     iPUup        = 4
     iPUdown      = 5
     iAltFitRange = 6
-    iAltSigBkgModel = 2
+    iAltSigBkgModel = 3
 
     def __init__(self,abin):
         self.ptBin   = abin
@@ -17,8 +17,9 @@ class efficiency:
         self.effMC   = -1
         self.altEff  = [-1]*7
         self.syst    = [-1]*7
+        self.mean    = -1
     
-    def __init__(self,ptBin,etaBin,effData,errEffData,effMC,errEffMC,effAltBkgModel,effAltSigModel,effAltMCSignal,effAltTagSel,effAltSigBkgModel):
+    def __init__(self,ptBin,etaBin,effData,errEffData,effMC,errEffMC,effAltBkgModel,effAltSigModel,effAltMCSignal,effAltSigBkgModel):
         self.ptBin      = ptBin
         self.etaBin     = etaBin
         self.effData    = effData
@@ -26,12 +27,14 @@ class efficiency:
         self.errEffData = errEffData        
         self.errEffMC   = errEffMC
         self.altEff = [-1]*7
-        self.syst   = [-1]*9
+        self.syst   = [-1]*7
         self.altEff[self.iAltBkgModel] = effAltBkgModel
         self.altEff[self.iAltSigModel] = effAltSigModel
         self.altEff[self.iAltMCSignal] = effAltMCSignal
-        self.altEff[self.iAltTagSelec] = effAltTagSel
+        # self.altEff[self.iAltTagSelec] = effAltTagSel
         self.altEff[self.iAltSigBkgModel] = effAltSigBkgModel
+        self.mean=(effAltBkgModel+effAltSigModel+effAltSigBkgModel+effData)/4
+
 
     def __str__(self):
         return '%2.3f\t%2.3f\t%2.1f\t%2.1f\t%2.4f\t%2.4f\t%2.4f\t%2.4f\t%2.4f\t%2.4f\t%2.4f\t%2.4f' % (self.etaBin[0],self.etaBin[1],
@@ -41,19 +44,19 @@ class efficiency:
 
     @staticmethod
     def getSystematicNames():
-        return [ 'statData', 'statMC', 'altBkgModel', 'altSignalModel', 'altMCEff', 'altTagSelection','altSigBkgModel' ]
+        return [ 'statData', 'statMC', 'altBkgModel', 'altSignalModel', 'altSigBkgModel' ,'nominal','altMC']
 
 
 
     def combineSyst(self,averageEffData,averageEffMC):
-        meanEff = (systAltBkg + systAltSig + systAltSigBkg + averageEffData)/4 # we use mean value of 4 variations insted of the nominal one
-        systAltBkg      = self.altEff[self.iAltBkgModel] - meanEff
-        systAltSig      = self.altEff[self.iAltSigModel] - meanEff
-        systAltMC       = self.altEff[self.iAltMCSignal] - averageEffMC
+        systNom         = self.effData - self.mean
+        systAltBkg      = self.altEff[self.iAltBkgModel] - self.mean
+        systAltSig      = self.altEff[self.iAltSigModel] - self.mean
+        systAltMC       = self.altEff[self.iAltMCSignal] - self.effMC
 #        systAltTagSelec = self.altEff[self.iAltTagSelec] - averageEffData
-        systAltSigBkg   = self.altEff[self.iAltSigBkgModel] - meanEff
+        systAltSigBkg   = self.altEff[self.iAltSigBkgModel] - self.mean
         # systAltTagSelec = self.altEff[self.iAltTagSelec] - averageEffMC
-        systAltTagSelec = 0 # we remove it as systematic as it is a cut test
+
 
         if self.altEff[self.iAltBkgModel] < 0:
             systAltBkg = 0
@@ -67,8 +70,8 @@ class efficiency:
         if self.altEff[self.iAltSigBkgModel] < 0:
             systAltSigBkg = 0
 
-        if self.altEff[self.iAltTagSelec] < 0:
-            systAltTagSelec = 0
+        # if self.altEff[self.iAltTagSelec] < 0:
+        #     systAltTagSelec = 0
 
         #don't include systMC when smaller than statMC
         if(systAltMC<self.errEffMC):
@@ -76,11 +79,13 @@ class efficiency:
 
         self.syst[ 0                 ] = self.errEffData
         self.syst[ 1                 ] = self.errEffMC
-        self.syst[self.iAltBkgModel+2] = systAltBkg
-        self.syst[self.iAltSigModel+2] = systAltSig
-        self.syst[self.iAltMCSignal-1] = systAltMC
-        self.syst[self.iAltTagSelec+2] = systAltTagSelec
-        self.syst[self.iAltSigBkgModel+2] = systAltSigBkg
+        self.syst[ 2                 ] = systAltBkg
+        self.syst[ 3                 ] = systAltSig
+        self.syst[ 4                 ] = systAltSigBkg
+        self.syst[ 5                 ] = systNom
+        self.syst[ 6                 ] = systAltMC
+        # self.syst[self.iAltTagSelec+2] = systAltTagSelec
+        
         
         self.systCombined = 0
         ##Sum in Q##
@@ -88,12 +93,16 @@ class efficiency:
         #     self.systCombined += self.syst[isyst]*self.syst[isyst];
 
         ##NEW PROPOSAL##
-        for isyst in range(2,6): #check if 6 is excluded!
-            self.systCombined = self.syst[isyst]*self.syst[isyst]
+        #print("eta bin: ",self.etaBin[0],self.etaBin[1])
+        #for isyst in range (7):
+           # print("isyst: ", isyst, " syst[isyst]: ", self.syst[isyst])
+        for isyst in range(2,6):
+            # print("isyst: ", isyst, " syst[isyst]: ", self.syst[isyst])
+            self.systCombined += self.syst[isyst]*self.syst[isyst]
         self.systCombined= math.sqrt(self.systCombined/3)
-
-        self.systCombined = math.sqrt(self.systCombined*self.systCombined/2 + self.syst[6]*self.syst[6] + self.syst[0]*self.syst[0]+ self.syst[1]*self.syst[1])
-        
+        #print("no stat: ",self.systCombined )
+        self.systCombined = math.sqrt(self.systCombined*self.systCombined/4 + self.syst[6]*self.syst[6] + self.syst[0]*self.syst[0]+ self.syst[1]*self.syst[1])
+        #print("syst + stat: ",self.systCombined )
 
     def __add__(self,eff):
         if self.effData < 0 :
@@ -118,10 +127,10 @@ class efficiency:
         newEffAltBkgModel = wData1 * self.altEff[self.iAltBkgModel] + wData2 * eff.altEff[self.iAltBkgModel]
         newEffAltSigModel = wData1 * self.altEff[self.iAltSigModel] + wData2 * eff.altEff[self.iAltSigModel]
         newEffAltMCSignal = wData1 * self.altEff[self.iAltMCSignal] + wData2 * eff.altEff[self.iAltMCSignal]
-        newEffAltTagSelec = wData1 * self.altEff[self.iAltTagSelec] + wData2 * eff.altEff[self.iAltTagSelec]
+        # newEffAltTagSelec = wData1 * self.altEff[self.iAltTagSelec] + wData2 * eff.altEff[self.iAltTagSelec]
         newEffAltSigBkgModel = wData1 * self.altEff[self.iAltSigBkgModel] + wData2 * eff.altEff[self.iAltSigBkgModel]
         
-        effout = efficiency(ptbin,etabin,newEffData,newErrEffData,newEffMC,newErrEffMC,newEffAltBkgModel,newEffAltSigModel,newEffAltMCSignal,newEffAltTagSelec,newEffAltSigBkgModel)
+        effout = efficiency(ptbin,etabin,newEffData,newErrEffData,newEffMC,newErrEffMC,newEffAltBkgModel,newEffAltSigModel,newEffAltMCSignal,newEffAltSigBkgModel)
         return effout
     
 
@@ -196,6 +205,7 @@ class efficiencyList:
     def symmetrizeSystVsEta(self):
         for ptBin in self.effList.keys():
             for etaBin in self.effList[ptBin].keys():
+                print("etaBin:  ",etaBin)
                 if etaBin[0] >= 0 and etaBin[1] > 0:
                     etaBinPlus  = etaBin
                     etaBinMinus = (-etaBin[1],-etaBin[0])
@@ -365,7 +375,7 @@ class efficiencyList:
                     aValue  = effAverage.effData
                     anError = effAverage.systCombined 
                     if doScaleFactor :
-                        aValue  = effAverage.effData      / effAverage.effMC
+                        aValue  = effAverage.mean      / effAverage.effMC
                         anError = effAverage.systCombined / effAverage.effMC  
                     listOfGraphs[etaBin].append( {'min': ptBin[0], 'max': ptBin[1],
                                                   'val': aValue  , 'err': anError } ) 
@@ -399,10 +409,10 @@ class efficiencyList:
                             effAverage = effPlus + effMinus
 
                         effAverage.combineSyst(effAverage.effData,effAverage.effMC)
-                        aValue  = effAverage.effData
+                        aValue  = effAverage.mean
                         anError = effAverage.systCombined 
                         if doScaleFactor :
-                            aValue  = effAverage.effData      / effAverage.effMC
+                            aValue  = effAverage.mean      / effAverage.effMC
                             anError = effAverage.systCombined / effAverage.effMC  
                         listOfGraphs[abin].append( {'min': ptBin[0], 'max': ptBin[1],
                                                     'val': aValue  , 'err': anError } ) 
@@ -422,10 +432,10 @@ class efficiencyList:
                     ### init average efficiency 
                     listOfGraphs[ptBin] = []
                 effAverage = self.effList[ptBin][etaBin]
-                aValue  = effAverage.effData
+                aValue  = effAverage.mean
                 anError = effAverage.systCombined 
                 if typeGR == 1:
-                    aValue  = effAverage.effData      / effAverage.effMC
+                    aValue  = effAverage.mean      / effAverage.effMC
                     anError = effAverage.systCombined / effAverage.effMC  
                 if typeGR == -1:
                     aValue  = effAverage.effMC

--- a/libPython/efficiencyUtils.py
+++ b/libPython/efficiencyUtils.py
@@ -318,22 +318,22 @@ class efficiencyList:
                         else:                        
                             averageMC   = (effPlus.effMC   + effMinus.effMC  )/2.
                         ### so this is h2D bin is inside the bining used by e/gamma POG
-                        h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].effData      / self.effList[ptBin][etaBin].effMC)
-                        h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].systCombined / averageMC )
+                        h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].mean      / self.effList[ptBin][etaBin].effMC)
+                        h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].systCombined / self.effList[ptBin][etaBin].effMC )
                         if onlyError   == 0 :
-                            h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].systCombined      / averageMC  )
+                            h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].systCombined      / self.effList[ptBin][etaBin].effMC  )
                         if   onlyError == -3 :
-                            h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].effData      )
-                            h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].systCombined * self.effList[ptBin][etaBin].effMC / averageMC )
+                            h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].mean      )
+                            h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].systCombined * self.effList[ptBin][etaBin].effMC / self.effList[ptBin][etaBin].effMC )
                         elif onlyError == -2 :
                             h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].effMC)
                             h2.SetBinError  (ix,iy, 0 )
                         elif onlyError == -1 :
-                            h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].effData      / self.effList[ptBin][etaBin].effMC)
-                            h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].systCombined / averageMC )
+                            h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].mean      / self.effList[ptBin][etaBin].effMC)
+                            h2.SetBinError  (ix,iy, self.effList[ptBin][etaBin].systCombined / self.effList[ptBin][etaBin].effMC )
 
                         if onlyError   == 0 :
-                                h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].systCombined      / averageMC  )
+                                h2.SetBinContent(ix,iy, self.effList[ptBin][etaBin].systCombined      / self.effList[ptBin][etaBin].effMC  )
                         elif onlyError >= 1 and onlyError <= 6:
                             denominator = averageMC
                             if relError:
@@ -372,7 +372,7 @@ class efficiencyList:
                         listOfGraphs[etaBin] = []
 
                     effAverage.combineSyst(effAverage.effData,effAverage.effMC)
-                    aValue  = effAverage.effData
+                    aValue  = effAverage.mean
                     anError = effAverage.systCombined 
                     if doScaleFactor :
                         aValue  = effAverage.mean      / effAverage.effMC
@@ -408,12 +408,12 @@ class efficiencyList:
                         if not effMinus is None:
                             effAverage = effPlus + effMinus
 
-                        effAverage.combineSyst(effAverage.effData,effAverage.effMC)
-                        aValue  = effAverage.mean
-                        anError = effAverage.systCombined 
+                        #effAverage.combineSyst(effAverage.effData,effAverage.effMC)
+                        aValue  = (effPlus.mean + effMinus.mean)/2   #we use abs eta (average between etaplus and etaminus) for pt plot
+                        anError = (effPlus.systCombined + effMinus.systCombined)/2
                         if doScaleFactor :
-                            aValue  = effAverage.mean      / effAverage.effMC
-                            anError = effAverage.systCombined / effAverage.effMC  
+                            aValue  = aValue   / effAverage.effMC
+                            anError = anError / effAverage.effMC  
                         listOfGraphs[abin].append( {'min': ptBin[0], 'max': ptBin[1],
                                                     'val': aValue  , 'err': anError } ) 
                                                   

--- a/libPython/fitUtils.py
+++ b/libPython/fitUtils.py
@@ -250,7 +250,7 @@ def histFitterAltBkg( sample, tnpBin, tnpWorkspaceParam ):
 #############################################################
 ########## alternate signal+background fitter
 #############################################################
-def histFitterAltSigBkg( sample, tnpBin, tnpWorkspaceParam ):
+def histFitterAltSigBkg( sample, tnpBin, tnpWorkspaceParam):
 
     tnpWorkspaceFunc = [
         "tailLeft[1]",
@@ -270,11 +270,13 @@ def histFitterAltSigBkg( sample, tnpBin, tnpWorkspaceParam ):
     hF = infile.Get('%s_Fail' % tnpBin['name'] )
     fitter = tnpFitter( hP, hF, tnpBin['name'] )
     infile.Close()
-
+    
     ## setup
-    rootfile = rt.TFile(sample.altSigBkgFit,'update')
+    rootpath = sample.altSigBkgFit.replace('.root', '-%s.root' % tnpBin['name'])
+    rootfile = rt.TFile(rootpath,'update')
     fitter.setOutputFile( rootfile )
 #    fitter.setFitRange(65,115)
+
 
     ## generated Z LineShape
     ## for high pT change the failing spectra to any probe to get statistics
@@ -296,7 +298,7 @@ def histFitterAltSigBkg( sample, tnpBin, tnpWorkspaceParam ):
     title = tnpBin['title'].replace(';',' - ')
     title = title.replace('probe_sc_eta','#eta_{SC}')
     title = title.replace('probe_Ele_pt','p_{T}')
-    fitter.fits(sample.mcTruth,title)
+    fitter.fits(sample.mcTruth,sample.isMC,title)
     rootfile.Close()
 
 

--- a/libPython/fitUtils.py
+++ b/libPython/fitUtils.py
@@ -247,3 +247,56 @@ def histFitterAltBkg( sample, tnpBin, tnpWorkspaceParam ):
     rootfile.Close()
 
 
+#############################################################
+########## alternate signal+background fitter
+#############################################################
+def histFitterAltSigBkg( sample, tnpBin, tnpWorkspaceParam ):
+
+    tnpWorkspaceFunc = [
+        "tailLeft[1]",
+        "RooCBExGaussShape::sigResPass(x,meanP,expr('sqrt(sigmaP*sigmaP+sosP*sosP)',{sigmaP,sosP}),alphaP,nP, expr('sqrt(sigmaP_2*sigmaP_2+sosP*sosP)',{sigmaP_2,sosP}),tailLeft)",
+        "RooCBExGaussShape::sigResFail(x,meanF,expr('sqrt(sigmaF*sigmaF+sosF*sosF)',{sigmaF,sosF}),alphaF,nF, expr('sqrt(sigmaF_2*sigmaF_2+sosF*sosF)',{sigmaF_2,sosF}),tailLeft)",
+        "Exponential::bkgPass(x, alphaP_2)",
+        "Exponential::bkgFail(x, alphaF_2)",
+        ]
+
+    tnpWorkspace = []
+    tnpWorkspace.extend(tnpWorkspaceParam)
+    tnpWorkspace.extend(tnpWorkspaceFunc)
+            
+    ## init fitter
+    infile = rt.TFile(sample.histFile,'read')
+    hP = infile.Get('%s_Pass' % tnpBin['name'] )
+    hF = infile.Get('%s_Fail' % tnpBin['name'] )
+    fitter = tnpFitter( hP, hF, tnpBin['name'] )
+    infile.Close()
+
+    ## setup
+    rootfile = rt.TFile(sample.altSigBkgFit,'update')
+    fitter.setOutputFile( rootfile )
+#    fitter.setFitRange(65,115)
+
+    ## generated Z LineShape
+    ## for high pT change the failing spectra to any probe to get statistics
+    fileTruth = rt.TFile(sample.mcRef.histFile,'read')
+    histZLineShapeP = fileTruth.Get('%s_Pass'%tnpBin['name'])
+    histZLineShapeF = fileTruth.Get('%s_Fail'%tnpBin['name'])
+    if ptMin( tnpBin ) > minPtForSwitch: 
+        histZLineShapeF = fileTruth.Get('%s_Pass'%tnpBin['name'])
+#        fitter.fixSigmaFtoSigmaP()
+    fitter.setZLineShapes(histZLineShapeP,histZLineShapeF)
+    fileTruth.Close()
+
+    ### set workspace
+    workspace = rt.vector("string")()
+    for iw in tnpWorkspace:
+        workspace.push_back(iw)
+    fitter.setWorkspace( workspace )
+
+    title = tnpBin['title'].replace(';',' - ')
+    title = title.replace('probe_sc_eta','#eta_{SC}')
+    title = title.replace('probe_Ele_pt','p_{T}')
+    fitter.fits(sample.mcTruth,title)
+    rootfile.Close()
+
+

--- a/libPython/rootUtils.py
+++ b/libPython/rootUtils.py
@@ -226,6 +226,34 @@ def getAllEffi( info, bindef ):
         rootfile.Close()
 
         effis['dataAltBkg'] = computeEffi(nP,nF,eP,eF)
+    
     else:
         effis['dataAltBkg'] = [-1,-1]
+    
+    if not info['dataAltSigBkg'] is None and os.path.isfile(info['dataAltSigBkg']) :
+        rootfile = rt.TFile( info['dataAltSigBkg'], 'read' )
+        from ROOT import RooFit,RooFitResult
+        fitresP = rootfile.Get( '%s_resP' % bindef['name']  )
+        fitresF = rootfile.Get( '%s_resF' % bindef['name'] )
+
+        nP = fitresP.floatParsFinal().find('nSigP').getVal()
+        nF = fitresF.floatParsFinal().find('nSigF').getVal()
+        eP = fitresP.floatParsFinal().find('nSigP').getError()
+        eF = fitresF.floatParsFinal().find('nSigF').getError()
+        rootfile.Close()
+
+        rootfile = rt.TFile( info['data'], 'read' )
+        hP = rootfile.Get('%s_Pass'%bindef['name'])
+        hF = rootfile.Get('%s_Fail'%bindef['name'])
+
+        # if eP > math.sqrt(hP.Integral()) : eP = math.sqrt(hP.Integral())
+        # if eF > math.sqrt(hF.Integral()) : eF = math.sqrt(hF.Integral())
+        rootfile.Close()
+
+        effis['dataAltSigBkg'] = computeEffi(nP,nF,eP,eF)
+
+    else:
+        effis['dataAltSigBkg'] = [-1,-1]
+        
     return effis
+    

--- a/tnpEGM_fitter.py
+++ b/tnpEGM_fitter.py
@@ -16,6 +16,7 @@ parser.add_argument('--sample'     , default='all'        , help = 'create histo
 parser.add_argument('--altSig'     , action='store_true'  , help = 'alternate signal model fit')
 parser.add_argument('--addGaus'    , action='store_true'  , help = 'add gaussian to alternate signal model failing probe')
 parser.add_argument('--altBkg'     , action='store_true'  , help = 'alternate background model fit')
+parser.add_argument('--altSigBkg'  , action='store_true'  , help = 'alternate signal and background model fit')
 parser.add_argument('--doFit'      , action='store_true'  , help = 'fit sample (sample should be defined in settings.py)')
 parser.add_argument('--mcSig'      , action='store_true'  , help = 'fit MC nom [to init fit parama]')
 parser.add_argument('--doPlot'     , action='store_true'  , help = 'plotting')
@@ -133,6 +134,7 @@ for s in tnpConf.samplesDef.keys():
     setattr( sample, 'nominalFit', '%s/%s_%s.nominalFit.root' % ( outputDirectory , sample.name, args.flag ) )
     setattr( sample, 'altSigFit' , '%s/%s_%s.altSigFit.root'  % ( outputDirectory , sample.name, args.flag ) )
     setattr( sample, 'altBkgFit' , '%s/%s_%s.altBkgFit.root'  % ( outputDirectory , sample.name, args.flag ) )
+    setattr( sample, 'altSigBkgFit' , '%s/%s_%s.altSigBkgFit.root'  % ( outputDirectory , sample.name, args.flag ) )
 
 
 
@@ -151,6 +153,8 @@ if  args.doFit:
                 tnpRoot.histFitterAltSig(  sampleToFit, tnpBins['bins'][ib], tnpConf.tnpParAltSigFit_addGaus, 1)
             elif args.altBkg:
                 tnpRoot.histFitterAltBkg(  sampleToFit, tnpBins['bins'][ib], tnpConf.tnpParAltBkgFit )
+            elif args.altSigBkg:
+                tnpRoot.histFitterAltSigBkg(  sampleToFit, tnpBins['bins'][ib], tnpConf.tnpParAltSigBkgFit )
             else:
                 tnpRoot.histFitterNominal( sampleToFit, tnpBins['bins'][ib], tnpConf.tnpParNomFit )
     pool = Pool()
@@ -170,6 +174,9 @@ if  args.doPlot:
     if args.altBkg : 
         fileName = sampleToFit.altBkgFit
         fitType  = 'altBkgFit'
+    if args.altSigBkg : 
+        fileName = sampleToFit.altSigBkgFit
+        fitType  = 'altSigBkgFit'
         
     os.system('hadd -f %s %s' % (fileName, fileName.replace('.root', '-*.root')))
 
@@ -196,6 +203,7 @@ if args.sumUp:
         'dataNominal' : sampleToFit.nominalFit,
         'dataAltSig'  : sampleToFit.altSigFit ,
         'dataAltBkg'  : sampleToFit.altBkgFit ,
+        'dataAltSigBkg'  : sampleToFit.altSigBkgFit ,
         'mcNominal'   : sampleToFit.mcRef.histFile,
         'mcAlt'       : None,
         'tagSel'      : None
@@ -231,6 +239,7 @@ if args.sumUp:
             effis['mcNominal'  ][0],effis['mcNominal'  ][1],
             effis['dataAltBkg' ][0],
             effis['dataAltSig' ][0],
+            effis['dataAltSigBkg' ][0],
             effis['mcAlt' ][0],
             effis['tagSel'][0],
             )

--- a/tnpEGM_fitter.py
+++ b/tnpEGM_fitter.py
@@ -159,6 +159,10 @@ if  args.doFit:
                 tnpRoot.histFitterNominal( sampleToFit, tnpBins['bins'][ib], tnpConf.tnpParNomFit )
     pool = Pool()
     pool.map(parallel_fit, range(len(tnpBins['bins'])))
+    
+    # for ib in range(len(tnpBins['bins'])):
+    #     if args.altSigBkg:
+    #         tnpRoot.histFitterAltSigBkg(  sampleToFit, tnpBins['bins'][ib], tnpConf.tnpParAltSigBkgFit )
 
     args.doPlot = True
      
@@ -209,10 +213,10 @@ if args.sumUp:
         'tagSel'      : None
         }
 
-    #if not tnpConf.samplesDef['mcAlt' ] is None:
-    #    info['mcAlt'    ] = tnpConf.samplesDef['mcAlt' ].histFile
-    if not tnpConf.samplesDef['tagSel'] is None:
-        info['tagSel'   ] = tnpConf.samplesDef['tagSel'].histFile
+    if not tnpConf.samplesDef['mcAlt' ] is None:
+       info['mcAlt'    ] = tnpConf.samplesDef['mcAlt' ].histFile
+    # if not tnpConf.samplesDef['tagSel'] is None:
+    #     info['tagSel'   ] = tnpConf.samplesDef['tagSel'].histFile
 
     effis = None
     effFileName ='%s/egammaEffi.txt' % outputDirectory 
@@ -239,9 +243,9 @@ if args.sumUp:
             effis['mcNominal'  ][0],effis['mcNominal'  ][1],
             effis['dataAltBkg' ][0],
             effis['dataAltSig' ][0],
-            effis['dataAltSigBkg' ][0],
             effis['mcAlt' ][0],
-            effis['tagSel'][0],
+            # effis['tagSel'][0],
+            effis['dataAltSigBkg' ][0],
             )
         print(astr)
         fOut.write( astr + '\n' )


### PR DESCRIPTION
This PR contains changes related to implementation of new proposal for using RMS method to calculate systematical part of uncertainty. See details in presentation [here](https://indico.cern.ch/event/1288547/contributions/5414376/attachments/2654622/4597206/26052023_RMS_EGamma.pdf)

Changes include:
- removal of alternative Tag variation which is only a cut variation
- adding an additional fit as combination of both alternative signal and background function applied at the same time (see **)
- Using mean value of SF as the central one and evaluation of the systematical part of the uncertainty as uncertainty on the mean RMS/sqrtN
- adding systematical part from alternative MC sample in cases where it is larger than the contribution from the statistical uncertainty from MC
- removed symmetrisation in eta (using the average value from eta+ and eta-) for the final uncertainty 

** in order to be able to use altSigBkg fit, settings file should be updated with fit parameters settings from [example](https://github.com/asculac/egm_tnp_analysis/blob/RMS_PR/etc/config/settings_UL2017_RMS_pt11_15.py#L156-L163)  

**NB!:**
Final egamma PDF is not fully correct yet, this should be investigated as the breakdown of the uncertainties shown in 2D histograms for the systematical contributions seems to be wrong. This is under investigation and any help with this will be much appreciated!