### PR TITLE
Added RooCBExGaussShapeTNP in AltSigBkg fit

### DIFF
--- a/libPython/fitUtils.py
+++ b/libPython/fitUtils.py
@@ -254,8 +254,8 @@ def histFitterAltSigBkg( sample, tnpBin, tnpWorkspaceParam):
 
     tnpWorkspaceFunc = [
         "tailLeft[1]",
-        "RooCBExGaussShape::sigResPass(x,meanP,expr('sqrt(sigmaP*sigmaP+sosP*sosP)',{sigmaP,sosP}),alphaP,nP, expr('sqrt(sigmaP_2*sigmaP_2+sosP*sosP)',{sigmaP_2,sosP}),tailLeft)",
-        "RooCBExGaussShape::sigResFail(x,meanF,expr('sqrt(sigmaF*sigmaF+sosF*sosF)',{sigmaF,sosF}),alphaF,nF, expr('sqrt(sigmaF_2*sigmaF_2+sosF*sosF)',{sigmaF_2,sosF}),tailLeft)",
+        "RooCBExGaussShapeTNP::sigResPass(x,meanP,expr('sqrt(sigmaP*sigmaP+sosP*sosP)',{sigmaP,sosP}),alphaP,nP, expr('sqrt(sigmaP_2*sigmaP_2+sosP*sosP)',{sigmaP_2,sosP}),tailLeft)",
+        "RooCBExGaussShapeTNP::sigResFail(x,meanF,expr('sqrt(sigmaF*sigmaF+sosF*sosF)',{sigmaF,sosF}),alphaF,nF, expr('sqrt(sigmaF_2*sigmaF_2+sosF*sosF)',{sigmaF_2,sosF}),tailLeft)",
         "Exponential::bkgPass(x, alphaP_2)",
         "Exponential::bkgFail(x, alphaF_2)",
         ]


### PR DESCRIPTION
This is just a small change in the AltSigBkg fit  in line with Fabrice's modifications before. I forgot to add it before. 